### PR TITLE
Fix CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pipenv
-          pipenv lock --dev --requirements > requirements.txt
+          pipenv requirements --dev > requirements.txt
           pip install -r requirements.txt
       - name: Test with pytest
         run: |


### PR DESCRIPTION
The --requirements option was removed from pipenv in version 2022.8.13. See https://github.com/pypa/pipenv/blob/main/CHANGELOG.rst#2022813-2022-08-13.

I've tested `pipenv requirements --dev > requirements.txt` locally and checked if `pip install -r requirements.txt` did something, but I haven't tested it in the CI workflow on Github.